### PR TITLE
Fix for card grid layout breaking when image was revealed

### DIFF
--- a/frontend/src/components/GameCard.vue
+++ b/frontend/src/components/GameCard.vue
@@ -57,9 +57,9 @@ const cardProperties = computed(() => {
             v-show="props.visibility === 'full' || props.visibility === 'color'">
             <div class="cardgrid">
                 <div class="imagebackground" :style="{ backgroundColor: cardProperties.imagebgcolorcode }">
-                    <img class="cardimage" v-show="props.visibility === 'full'" :src="cardProperties.imageurl" />
+                  <div class="cardimage" :style="{ backgroundImage: `url(${cardProperties.imageurl})` }" v-show="props.visibility === 'full'"></div>
                 </div>
-                <div class="rotated mt-3 mr-3" v-show="props.visibility === 'full'">
+                <div class="rotated mt-3 mr-2" v-show="props.visibility === 'full'">
                     <h1 class="cardtitle title has-text-left is-size-1">{{ cardProperties.cardname.toUpperCase() }}</h1>
                     <p class="has-text-left carddesc mt-1">{{cardProperties.summary}}</p>
                 </div>
@@ -95,8 +95,7 @@ const cardProperties = computed(() => {
 .cardimage {
     width: 100%;
     height: 100%;
-    object-position: left top;
-    object-fit: contain;
+    background-size: cover;
 }
 
 .imagebackground {

--- a/frontend/src/components/GameCard.vue
+++ b/frontend/src/components/GameCard.vue
@@ -8,7 +8,7 @@ const props = defineProps({
   cardname: String
 })
 
-function cardColorCode(color) {
+function cardColorCode (color) {
   let bgcolor = '#ffffff'
   switch (color) {
     case 'blue':
@@ -24,7 +24,7 @@ function cardColorCode(color) {
   return bgcolor
 }
 
-function imageBgColor(color) {
+function imageBgColor (color) {
   let imgcolor = '#ffffff'
   switch (color) {
     case 'blue':

--- a/frontend/src/components/GameCard.vue
+++ b/frontend/src/components/GameCard.vue
@@ -8,7 +8,7 @@ const props = defineProps({
   cardname: String
 })
 
-function cardColorCode (color) {
+function cardColorCode(color) {
   let bgcolor = '#ffffff'
   switch (color) {
     case 'blue':
@@ -24,7 +24,7 @@ function cardColorCode (color) {
   return bgcolor
 }
 
-function imageBgColor (color) {
+function imageBgColor(color) {
   let imgcolor = '#ffffff'
   switch (color) {
     case 'blue':
@@ -52,83 +52,84 @@ const cardProperties = computed(() => {
 </script>
 
 <template>
-    <div class="gamecard box">
-        <div class="cardface" :style="{ backgroundColor: cardProperties.colorcode }"
-            v-show="props.visibility === 'full' || props.visibility === 'color'">
-            <div class="cardgrid">
-                <div class="imagebackground" :style="{ backgroundColor: cardProperties.imagebgcolorcode }">
-                  <div class="cardimage" :style="{ backgroundImage: `url(${cardProperties.imageurl})` }" v-show="props.visibility === 'full'"></div>
-                </div>
-                <div class="rotated mt-3 mr-2" v-show="props.visibility === 'full'">
-                    <h1 class="cardtitle title has-text-left is-size-1">{{ cardProperties.cardname.toUpperCase() }}</h1>
-                    <p class="has-text-left carddesc mt-1">{{cardProperties.summary}}</p>
-                </div>
-                <h3 class="carddesc has-text-left ml-2 mr-1 mt-1" v-show="props.visibility === 'full'">{{
-                    cardProperties.description }}
-                </h3>
-            </div>
+  <div class="gamecard box">
+    <div class="cardface" :style="{ backgroundColor: cardProperties.colorcode }"
+      v-show="props.visibility === 'full' || props.visibility === 'color'">
+      <div class="cardgrid">
+        <div class="imagebackground" :style="{ backgroundColor: cardProperties.imagebgcolorcode }">
+          <div class="cardimage" :style="{ backgroundImage: `url(${cardProperties.imageurl})` }"
+            v-show="props.visibility === 'full'"></div>
         </div>
+        <div class="rotated mt-3 mr-2" v-show="props.visibility === 'full'">
+          <h1 class="cardtitle title has-text-left is-size-1">{{ cardProperties.cardname.toUpperCase() }}</h1>
+          <p class="has-text-left carddesc mt-1">{{cardProperties.summary}}</p>
+        </div>
+        <h3 class="carddesc has-text-left ml-2 mr-1 mt-1" v-show="props.visibility === 'full'">{{
+        cardProperties.description }}
+        </h3>
+      </div>
     </div>
+  </div>
 </template>
 
 <style>
 .gamecard {
-    box-sizing: border-box;
-    width: 100%;
-    aspect-ratio: 5/7;
+  box-sizing: border-box;
+  width: 100%;
+  aspect-ratio: 5/7;
 }
 
 .cardface {
-    height: 100%;
-    flex-direction: column;
-    align-items: center;
-    background-color: #3e4ea9;
+  height: 100%;
+  flex-direction: column;
+  align-items: center;
+  background-color: #3e4ea9;
 }
 
 .cardgrid {
-    display: grid;
-    height: 100%;
-    grid-template-columns: 2fr 1fr;
-    grid-template-rows: 3fr 1fr;
+  display: grid;
+  height: 100%;
+  grid-template-columns: 2fr 1fr;
+  grid-template-rows: 3fr 1fr;
 }
 
 .cardimage {
-    width: 100%;
-    height: 100%;
-    background-size: cover;
+  width: 100%;
+  height: 100%;
+  background-size: cover;
 }
 
 .imagebackground {
-    width: 100%;
-    height: 100%;
+  width: 100%;
+  height: 100%;
 }
 
 .cardtitle,
 .carddesc {
-    color: white;
+  color: white;
 }
 
 .carddesc {
-    grid-column: 1/3;
+  grid-column: 1/3;
 }
 
 .rotated {
-    writing-mode: vertical-rl;
+  writing-mode: vertical-rl;
 }
 
 .vertcenter {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 
 .imagecontainer {
-    height: 100%;
-    width: 100%;
+  height: 100%;
+  width: 100%;
 }
 
 .carddesc {
-    overflow: auto;
+  overflow: auto;
 }
 </style>


### PR DESCRIPTION
fixes #2 by using a CSS image-background rather than an HTML img tag

Card grid layout is now maintained between color and full reveal modes